### PR TITLE
Creating OpsGenie alerts with P1

### DIFF
--- a/internal/opsgenie/opsgenie.go
+++ b/internal/opsgenie/opsgenie.go
@@ -66,7 +66,7 @@ func (s *Service) CreateAlert(ctx context.Context, id string, title string, desc
 			"url": url,
 		},
 		Alias:    id,
-		Priority: alert.P3,
+		Priority: alert.P1,
 		User:     s.LinearUserAgent,
 	})
 	return err


### PR DESCRIPTION
Changing the priority of alerts created in OpsGenie to P1.

Reasoning: This package is used to escalate high priority tickets from Linear to OpsGenie. In OpsGenie these shall have a high priority too.